### PR TITLE
feat/flask: exposing flask_app in proxy instances

### DIFF
--- a/nboost/proxy.py
+++ b/nboost/proxy.py
@@ -59,6 +59,7 @@ class Proxy:
 
         static_dir = str(PKG_PATH.joinpath('resources/frontend'))
         flask_app = Flask(__name__)
+        self.wsgi_app = flask_app
 
         @flask_app.route(frontend_route, methods=['GET'])
         def frontend_root():


### PR DESCRIPTION
Exposing flask app would enable the use of WSGI servers other than flask built-in server