### PR TITLE
fix/database: create data directory if it does not exist

### DIFF
--- a/nboost/database.py
+++ b/nboost/database.py
@@ -1,3 +1,4 @@
+import os
 import time
 from typing import Optional
 from sqlite3 import Cursor
@@ -7,6 +8,8 @@ from nboost import defaults
 
 class Database:
     def __init__(self, db_file: type(defaults.db_file) = defaults.db_file, **_):
+        if not os.path.exists(defaults.data_dir):
+            os.makedirs(defaults.data_dir)
         self.db_file = db_file
 
     def new_row(self):


### PR DESCRIPTION
Fixing a bug when Database can't create the db file because the data_dir does not exist